### PR TITLE
Don't keep temp file open to allow other processes to open it on Windows

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -249,6 +249,7 @@ class Data(Iterator):
             self.save_to(tmp)
             tmp.flush()
             tmp.seek(0)
+            tmp.close()
             yield tmp
         finally:
             try:


### PR DESCRIPTION
Required to make https://github.com/mbr/latex/ work on Windows.
Could possibly break existing projects, which expect to get an opened file handle...
